### PR TITLE
Fix typo in plugins documentation

### DIFF
--- a/views/docs/plugins/index.ejs
+++ b/views/docs/plugins/index.ejs
@@ -21,7 +21,7 @@
 
 
     <h3>Naming and accessing plugins</h3>
-    <p>It is also possible to add options and load multiple instances of tha same plugins (if the plugin itself allows it).</p>
+    <p>It is also possible to add options and load multiple instances of the same plugins (if the plugin itself allows it).</p>
     <p>
       If the property <code>name</code> is added in the plugin <code>option</code> parameter does the plugin become
       accessible through listObj.namePropertyValue.This is useful when having multiple instances of the same plugin.


### PR DESCRIPTION
"tha" -> "the"
