### PR TITLE
Fix extraneous brackets around plugins

### DIFF
--- a/views/docs/plugins/fuzzysearch.ejs
+++ b/views/docs/plugins/fuzzysearch.ejs
@@ -58,7 +58,7 @@ var fuzzyOptions = {
 var options = {
   valueNames: [ 'name', 'category' ],
   plugins: [
-    [  ListFuzzySearch() ]
+    ListFuzzySearch()
   ]
 };
 


### PR DESCRIPTION
The Fuzzy Search plugin example in the documentation causes a fatal error:

```
Uncaught TypeError: undefined is not a function 
```
