### PR TITLE
Update options.plugins to be an array as expected, fix typo

### DIFF
--- a/views/docs/plugins/build.ejs
+++ b/views/docs/plugins/build.ejs
@@ -48,7 +48,7 @@
     </ul>
 
     <h3>Live example</h3>
-    <p>To be added<1--<a href="/examples/plugin">Check this out!</a>--></p>
+    <p>To be added<!--<a href="/examples/plugin">Check this out!</a>--></p>
 
     <% locals.mediaTempleTerm = "plugin" %>
 


### PR DESCRIPTION
I was creating a plugin for the first time and didn't realize plugins needed to be an array. Also, fixed a typo. The example link doesn't work, and I don't know what is supposed to be on that page... 

A few of your other example pages are broken:
http://listjs.com/examples/annotated-example
http://listjs.com/examples/menu
